### PR TITLE
fix: shallow copy imports array to avoid sorting of parent array

### DIFF
--- a/src/utils/main/main.generator.ts
+++ b/src/utils/main/main.generator.ts
@@ -152,7 +152,7 @@ export class MainGenerator {
   }
 
   private generateImports(els: { name: string; path: string }[], relative: boolean): MainGenerator {
-    els
+    [...els]
       .sort((a, b) => a.path.localeCompare(b.path))
       .forEach(({ name, path }) => {
         path = path.replace(/\.(?:ts|js)$/, "");


### PR DESCRIPTION
## What does this PR do?

## How do you test this PR?
